### PR TITLE
pypng on my platform returns an iterator for pixelData

### DIFF
--- a/HiSprite.py
+++ b/HiSprite.py
@@ -30,7 +30,7 @@ def main(argv):
 
 	width = pngdata[0]
 	height = pngdata[1]
-	pixelData = pngdata[2]	
+	pixelData = list(pngdata[2])
 	byteWidth = width/2+1+1	 # TODO: Calculate a power of two for this
 	niceName = os.path.splitext(pngfile)[0].upper()
 	


### PR DESCRIPTION
instead of a sequence of bytes, causing a failure in pixelColor. I had to force pixelData to a list. I'm on linux, haven't tried other platforms so it may be linux specific pypng issues.